### PR TITLE
feat: provide actions from smaller repositories

### DIFF
--- a/destroy-network/action.yml
+++ b/destroy-network/action.yml
@@ -1,0 +1,22 @@
+name: Destroy Network
+description: Destroys an existing network
+inputs:
+  network-name:
+    description: The name of the network
+    required: true
+  provider:
+    description: The cloud provider. Accepts 'aws' or 'digital-ocean'.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Destroy testnet
+      env:
+        NETWORK_NAME: ${{ inputs.network-name }}
+        PROVIDER: ${{ inputs.provider }}
+      shell: bash
+      run: |
+        set -e
+        cd sn-testnet-deploy
+        testnet-deploy clean --name "$NETWORK_NAME" --provider "$PROVIDER"

--- a/init-testnet-deploy/action.yml
+++ b/init-testnet-deploy/action.yml
@@ -1,0 +1,124 @@
+name: Init Testnet Deploy
+description: >
+  Sets up testnet-deploy to be used as part of workflow. A version can be specified, or a repository
+  owner and branch can be used. The latter will build the binary from source. This can be useful for
+  testing from a fork. Many of these inputs are secrets that are used to 
+inputs:
+  ansible-vault-password:
+    description: Password for Ansible vault
+    required: true
+  aws-access-key-id:
+    description: AWS access key ID
+    required: true
+  aws-access-key-secret:
+    description: AWS access key
+    required: true
+  aws-region:
+    description: AWS region
+    default: eu-west-2
+    required: true
+  branch:
+    description: >
+      The branch of the testnet-deploy repository you wish to build from. If this argument is used,
+      testnet-deploy will be built from source.
+  do-token:
+    description: Digital Ocean Authorization token
+    required: true
+  org:
+    description: >
+      The organisation/user of the testnet-deploy repository you wish to build from. If this
+      argument is used, testnet-deploy will be built from source.
+  ssh-secret-key:
+    description: SSH key that Ansible will use to connect to the node VMs.
+    required: true
+  version:
+    description: Specify a version of testnet-deploy to use. Otherwise the latest will be used.
+
+runs:
+  using: composite
+  steps:
+    - name: install terraform
+      uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_wrapper: false
+
+    - name: install ansible
+      shell: bash
+      run: |
+        sudo apt-get update -y
+        # There is some issue with the latest version of Ansible not correctly
+        # reading the Digital Ocean token from environment variables, so just
+        # pin to this version for now.
+        pip install --user ansible==8.2.0
+        pip install --user boto3
+        sudo apt-get install jq -y
+    - name: configure testnet-deploy
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
+        AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-access-key-secret }}
+        DO_PAT: ${{ inputs.do-token }}
+        TERRAFORM_STATE_BUCKET_NAME: maidsafe-org-infra-tfstate
+      shell: bash
+      run: |
+        set -e
+
+        mkdir ~/.ssh
+        echo "${{ inputs.ssh-secret-key }}" >> ~/.ssh/id_rsa
+        chmod 0400 ~/.ssh/id_rsa
+        ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
+
+        mkdir ~/.ansible
+        echo "${{ inputs.ansible-vault-password }}" >> ~/.ansible/vault-password
+
+        echo "ANSIBLE_VAULT_PASSWORD_PATH=/home/runner/.ansible/vault-password" >> $GITHUB_ENV
+        echo "AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}" >> $GITHUB_ENV
+        echo "AWS_DEFAULT_REGION=${{ env.AWS_DEFAULT_REGION }}" >> $GITHUB_ENV
+        echo "AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}" >> $GITHUB_ENV
+        echo "DO_PAT=${{ env.DO_PAT }}" >> $GITHUB_ENV
+        echo "SSH_KEY_PATH=/home/runner/.ssh/id_rsa" >> $GITHUB_ENV
+        echo "TERRAFORM_STATE_BUCKET_NAME=${{ env.TERRAFORM_STATE_BUCKET_NAME }}" >> $GITHUB_ENV
+
+    - name: clone and build testnet-deploy
+      if: ${{ inputs.branch != '' }}
+      env:
+        TESTNET_DEPLOY_BRANCH: ${{ inputs.branch }}
+        TESTNET_DEPLOY_ORG: ${{ inputs.org }}
+      shell: bash
+      run: |
+        set -e
+
+        git clone --quiet --single-branch --depth 1 \
+          --branch $TESTNET_DEPLOY_BRANCH https://github.com/$TESTNET_DEPLOY_ORG/sn-testnet-deploy
+
+        cd sn-testnet-deploy
+        cargo build --release
+        sudo cp target/release/testnet-deploy /usr/local/bin
+
+    - name: download a binary
+      if: ${{ inputs.branch == '' }}
+      env:
+        BASE_URL: https://sn-testnet-deploy.s3.eu-west-2.amazonaws.com
+      shell: bash
+      run: |
+        set -e
+
+        if [[ -n "${{ inputs.version }}" ]]; then
+          version="${{ inputs.version }}"
+        else
+          version=$(curl --silent https://crates.io/api/v1/crates/sn-testnet-deploy | \
+            jq -r .crate.newest_version)
+        fi
+
+        # We still need the source because that's where the Terraform and Ansible files are. Longer
+        # term we could copy these to a system-wide location and extend the testnet tool to look
+        # there.
+        git clone https://github.com/maidsafe/sn-testnet-deploy
+        (
+          cd sn-testnet-deploy
+          git checkout v${version}
+        )
+
+        curl -L -O $BASE_URL/testnet-deploy-${version}-x86_64-unknown-linux-musl.zip
+        unzip testnet-deploy-${version}-x86_64-unknown-linux-musl.zip
+        sudo cp testnet-deploy /usr/local/bin

--- a/launch-network/action.yml
+++ b/launch-network/action.yml
@@ -1,0 +1,125 @@
+name: Launch Network
+description: Launches a remote Autonomi network with a given specification
+inputs:
+  ansible-forks:
+    description: The number of forks to use with Ansible
+  ansible-verbose:
+    description: Set to use verbose output for Ansible
+    default: false
+  beta-encryption-key:
+    description: Supply an encryption key that will be used with the auditor.
+  bootstrap-node-count:
+    description: Number of node services to run on each bootstrap node VM
+  bootstrap-node-vm-count:
+    description: Number of bootstrap node VMs to be deployed
+  environment-type:
+    description: >
+      Possible values are 'development', 'staging' and 'production'. This value determines the sizes
+      and counts of VMs. The counts can be overridden with the other count inputs.
+    required: true
+  faucet-version:
+    description: Supply a version for the faucet. Otherwise the latest will be used.
+  log-format:
+    description: Set the log format for the nodes, can be 'json' or 'default'. Defaults to 'default' if not set.
+  network-contacts-file-name:
+    description: Provide a name for the network contacts file
+  network-name:
+    description: The name of the testnet.
+    required: true
+  node-count:
+    description: Number of node services to run on each node VM
+  node-vm-count:
+    description: Number of node VMs to be deployed
+  public-rpc:
+    description: Set to make node manager RPC daemons publicly accessible
+    required: true
+    default: false
+  protocol-version:
+    description: The network protocol version can be set to 'restricted' or any custom version string.
+  provider:
+    description: The cloud provider. Accepts 'aws' or 'digital-ocean'.
+    required: true
+  rust-log:
+    description: Set RUST_LOG to this value for testnet-deploy
+    required: false
+  safenode-features:
+    description: Comma-separated list of features to be used when building a branch of safenode
+  safe-version:
+    description: Supply a version for safe. Otherwise the latest will be used.
+  safenode-version:
+    description: Supply a version for safenode. Otherwise the latest will be used.
+  safenode-manager-version:
+    description: Supply a version for safenode-manager. Otherwise the latest will be used.
+  safe-network-branch:
+    description: >
+      Build binaries from the specified safe_network branch. The testnet will use these binaries.
+  safe-network-user:
+    description: >
+      Build binaries from the safe_network repository owned by this org or username. The testnet
+      will use these binaries.
+  sn-auditor-version:
+    description: Supply a version for the sn-auditor. Otherwise the latest will be used.
+  uploader-vm-count:
+    description: Number of uploader VMs to be deployed
+
+runs:
+  using: composite
+  steps:
+    - name: Create network
+      env:
+        ANSIBLE_FORKS: ${{ inputs.ansible-forks }}
+        ANSIBLE_VERBOSE: ${{ inputs.ansible-verbose }}
+        BETA_ENCRYPTION_KEY: ${{ inputs.beta-encryption-key }}
+        BOOTSTRAP_NODE_COUNT: ${{ inputs.bootstrap-node-count }}
+        BOOTSTRAP_NODE_VM_COUNT: ${{ inputs.bootstrap-node-vm-count }}
+        ENVIRONMENT_TYPE: ${{ inputs.environment-type }}
+        FAUCET_VERSION: ${{ inputs.faucet-version }}
+        LOG_FORMAT: ${{ inputs.log-format }}
+        NETWORK_CONTACTS_FILE_NAME: ${{ inputs.network-contacts-file-name }}
+        NETWORK_NAME: ${{ inputs.network-name }}
+        NODE_COUNT: ${{ inputs.node-count }}
+        NODE_VM_COUNT: ${{ inputs.node-vm-count }}
+        PROTOCOL_VERSION: ${{ inputs.protocol-version }}
+        PROVIDER: ${{ inputs.provider }}
+        PUBLIC_RPC: ${{ inputs.public-rpc }}
+        RUST_LOG: ${{ inputs.rust-log }}
+        SAFENODE_FEATURES: ${{ inputs.safenode-features }}
+        SAFE_VERSION: ${{ inputs.safe-version }}
+        SAFENODE_VERSION: ${{ inputs.safenode-version }}
+        SAFENODE_MANAGER_VERSION: ${{ inputs.safenode-manager-version }}
+        SAFE_NETWORK_BRANCH: ${{ inputs.safe-network-branch }}
+        SAFE_NETWORK_USER: ${{ inputs.safe-network-user }}
+        SN_AUDITOR_VERSION: ${{ inputs.sn-auditor-version }}
+        UPLOADER_VM_COUNT: ${{ inputs.uploader-vm-count }}
+      shell: bash
+      run: |
+        set -e
+
+        cd sn-testnet-deploy
+        command="testnet-deploy deploy \
+          --name $NETWORK_NAME \
+          --environment-type $ENVIRONMENT_TYPE \
+          --provider $PROVIDER "
+        [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
+        [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose "
+        [[ -n $BETA_ENCRYPTION_KEY ]] && command="$command --beta-encryption-key $BETA_ENCRYPTION_KEY "
+        [[ -n $BOOTSTRAP_NODE_COUNT ]] && command="$command --bootstrap-node-count $BOOTSTRAP_NODE_COUNT "
+        [[ -n $BOOTSTRAP_NODE_VM_COUNT ]] && command="$command --bootstrap-node-vm-count $BOOTSTRAP_NODE_VM_COUNT "
+        [[ -n $FAUCET_VERSION ]] && command="$command --faucet-version $FAUCET_VERSION "
+        [[ -n $LOG_FORMAT ]] && command="$command --log-format $LOG_FORMAT "
+        [[ -n $NETWORK_CONTACTS_FILE_NAME ]] && command="$command --network-contacts-file-name $NETWORK_CONTACTS_FILE_NAME "
+        [[ -n $NODE_COUNT ]] && command="$command --node-count $NODE_COUNT "
+        [[ -n $NODE_VM_COUNT ]] && command="$command --node-vm-count $NODE_VM_COUNT "
+        [[ -n $PROTOCOL_VERSION ]] && command="$command --protocol-version $PROTOCOL_VERSION "
+        [[ $PUBLIC_RPC == "true" ]] && command="$command --public-rpc "
+        [[ -n $SAFENODE_FEATURES ]] && command="$command --safenode-features $SAFENODE_FEATURES "
+        [[ -n $SAFE_VERSION ]] && command="$command --safe-version $SAFE_VERSION "
+        [[ -n $SAFENODE_VERSION ]] && command="$command --safenode-version $SAFENODE_VERSION "
+        [[ -n $SAFENODE_MANAGER_VERSION ]] && command="$command --safenode-manager-version $SAFENODE_MANAGER_VERSION "
+        [[ -n $SN_AUDITOR_VERSION ]] && command="$command --sn-auditor-version $SN_AUDITOR_VERSION "
+        [[ -n $SAFE_NETWORK_BRANCH ]] && command="$command --branch $SAFE_NETWORK_BRANCH "
+        [[ -n $SAFE_NETWORK_USER ]] && command="$command --repo-owner $SAFE_NETWORK_USER "
+        [[ -n $UPLOADER_VM_COUNT ]] && command="$command --uploader-vm-count $UPLOADER_VM_COUNT "
+
+        echo "Will run testnet-deploy with: $command"
+        eval $command

--- a/network-status/action.yml
+++ b/network-status/action.yml
@@ -1,0 +1,26 @@
+name: Network Status
+description: Use testnet-deploy to get the current status of a deployment
+inputs:
+  ansible-forks:
+    description: The number of forks, or parallel connections, to use with Ansible. Defaults to 50.
+  network-name:
+    description: The name of the network
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: status
+      env:
+        ANSIBLE_FORKS: ${{ inputs.ansible-forks }}
+        NETWORK_NAME: ${{ inputs.network-name }}
+      shell: bash
+      run: |
+        set -e
+
+        cd sn-testnet-deploy
+        command="testnet-deploy status --name $NETWORK_NAME "
+        [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
+
+        echo "Will run testnet-deploy with: $command"
+        eval $command

--- a/print-inventory/action.yml
+++ b/print-inventory/action.yml
@@ -1,0 +1,25 @@
+name: Print Inventory
+description: Prints the inventory for a given network
+inputs:
+  ansible-forks:
+    description: The number of forks to use with Ansible
+  network-contacts-file-name:
+    description: Provide a name for the network contacts file
+  network-name:
+    description: The name of the network
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: print inventory
+      env:
+        PROVIDER: ${{ inputs.provider }}
+        NETWORK_CONTACTS_FILE_NAME: ${{ inputs.network-contacts-file-name }}
+        NETWORK_NAME: ${{ inputs.network-name }}
+      shell: bash
+      run: |
+        cd sn-testnet-deploy
+        command="testnet-deploy inventory --name $NETWORK_NAME --force-regeneration "
+        [[ -n $NETWORK_CONTACTS_FILE_NAME ]] && command="$command --network-contacts-file-name $NETWORK_CONTACTS_FILE_NAME"
+        eval $command

--- a/start-nodes/action.yml
+++ b/start-nodes/action.yml
@@ -1,0 +1,26 @@
+name: Start Nodes
+description: Use testnet-deploy to start all nodes for a deployment
+inputs:
+  ansible-forks:
+    description: The number of forks, or parallel connections, to use with Ansible. Defaults to 50.
+  network-name:
+    description: The name of the network
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: start
+      env:
+        ANSIBLE_FORKS: ${{ inputs.ansible-forks }}
+        NETWORK_NAME: ${{ inputs.network-name }}
+      shell: bash
+      run: |
+        set -e
+
+        cd sn-testnet-deploy
+        command="testnet-deploy start --name $NETWORK_NAME "
+        [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
+
+        echo "Will run testnet-deploy with: $command"
+        eval $command

--- a/stop-telegraf/action.yml
+++ b/stop-telegraf/action.yml
@@ -1,0 +1,26 @@
+name: Stop Telegraf
+description: Use testnet-deploy to stop the Telegraf service on all VMs
+inputs:
+  ansible-forks:
+    description: The number of forks, or parallel connections, to use with Ansible. Defaults to 50.
+  network-name:
+    description: The name of the network
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: stop telegraf
+      env:
+        ANSIBLE_FORKS: ${{ inputs.ansible-forks }}
+        NETWORK_NAME: ${{ inputs.network-name }}
+      shell: bash
+      run: |
+        set -e
+
+        cd sn-testnet-deploy
+        command="testnet-deploy stop-telegraf --name $NETWORK_NAME "
+        [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
+
+        echo "Will run testnet-deploy with: $command"
+        eval $command

--- a/upgrade-network/action.yml
+++ b/upgrade-network/action.yml
@@ -1,0 +1,68 @@
+name: Upgrade Network
+description: Use testnet-deploy to upgrade a network
+inputs:
+  ansible-forks:
+    description: >
+      The number of forks to use with Ansible. A network should be upgraded gradually, so this
+      should be small. The default used by testnet-deploy is 2.
+  ansible-verbose:
+    description: Set to true to run Ansible with its most verbose output
+  custom-inventory:
+    description: >
+      Run the upgrade against particular VMs in the environment.
+      Should be a comma-separated list.
+  faucet-version:
+    description: >
+      The faucet version to upgrade to. If not supplied, `testnet-deploy` will use the latest
+      version.
+  interval:
+    description: The interval to apply between each node upgrade. Units are ms. The default is 200.
+  network-name:
+    description: The name of the network to upgrade
+    required: true
+  safenode-version:
+    description: >
+      The safenode version to upgrade to. If not supplied, `testnet-deploy` will use the latest
+      version.
+  sn-auditor-version:
+    description: >
+      The auditor version to upgrade to. If not supplied, `testnet-deploy` will use the latest
+      version.
+
+runs:
+  using: composite
+  steps:
+    - name: upgrade network
+      env:
+        ANSIBLE_FORKS: ${{ inputs.ansible-forks }}
+        ANSIBLE_VERBOSE: ${{ inputs.ansible-verbose }}
+        AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
+        CUSTOM_INVENTORY: ${{ inputs.custom-inventory }}
+        FAUCET_VERSION: ${{ inputs.faucet-version }}
+        INTERVAL: ${{ inputs.interval }}
+        NETWORK_NAME: ${{ inputs.network-name }}
+        SAFENODE_VERSION: ${{ inputs.safenode-version }}
+        # The auditor argument won't be used for now. It is not available on the `upgrade` command
+        # yet, and the auditor upgrade could well be a separate command.
+        SN_AUDITOR_VERSION: ${{ inputs.sn-auditor-version }}
+      shell: bash
+      run: |
+        set -e
+
+        cd sn-testnet-deploy
+        command="testnet-deploy upgrade --name $NETWORK_NAME "
+        [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose "
+        [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
+        [[ -n $FAUCET_VERSION ]] && command="$command --faucet-version $FAUCET_VERSION "
+        [[ -n $INTERVAL ]] && command="$command --interval $INTERVAL "
+        [[ -n $SAFENODE_VERSION ]] && command="$command --safenode-version $SAFENODE_VERSION "
+
+        if [[ -n $CUSTOM_INVENTORY ]]; then
+          IFS=',' read -ra VM_NAMES <<< "$CUSTOM_INVENTORY"
+          for vm_name in "${VM_NAMES[@]}"; do
+            command="$command --custom-inventory $vm_name"
+          done
+        fi
+
+        echo "Will run testnet-deploy with: $command"
+        eval $command

--- a/upgrade-node-man/action.yml
+++ b/upgrade-node-man/action.yml
@@ -1,0 +1,26 @@
+name: Upgrade Node Manager
+description: Upgrade the node manager binary on all VMs in the deployment
+inputs:
+  network-name:
+    description: The name of the network to upgrade
+    required: true
+  version:
+    description: The safenode-manager version to upgrade to
+
+runs:
+  using: composite
+  steps:
+    - name: upgrade node manager
+      env:
+        NETWORK_NAME: ${{ inputs.network-name }}
+        SAFENODE_MANAGER_VERSION: ${{ inputs.version }}
+      shell: bash
+      run: |
+        set -e
+
+        cd sn-testnet-deploy
+        command="testnet-deploy upgrade-node-manager --name $NETWORK_NAME "
+        [[ -n $SAFENODE_MANAGER_VERSION ]] && command="$command --version $SAFENODE_MANAGER_VERSION "
+
+        echo "Will run testnet-deploy with: $command"
+        eval $command

--- a/upgrade-telegraf-config/action.yml
+++ b/upgrade-telegraf-config/action.yml
@@ -1,0 +1,32 @@
+name: Upgrade Telegraf Config
+description: Pull the latest Telegraf configuration from the network-dashboards repository
+inputs:
+  ansible-forks:
+    description: >
+      The number of forks to use with Ansible. A network should be upgraded gradually, so this
+      should be small. The default used by testnet-deploy is 2.
+  ansible-verbose:
+    description: Set to true to run Ansible with its most verbose output
+  network-name:
+    description: The name of the network to upgrade
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: upgrade telegraf
+      env:
+        ANSIBLE_FORKS: ${{ inputs.ansible-forks }}
+        ANSIBLE_VERBOSE: ${{ inputs.ansible-verbose }}
+        NETWORK_NAME: ${{ inputs.network-name }}
+      shell: bash
+      run: |
+        set -e
+
+        cd sn-testnet-deploy
+        command="testnet-deploy upgrade-telegraf --name $NETWORK_NAME "
+        [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose "
+        [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
+
+        echo "Will run testnet-deploy with: $command"
+        eval $command

--- a/upscale-network/action.yml
+++ b/upscale-network/action.yml
@@ -1,0 +1,58 @@
+name: Upscale Network
+description: Upscale an existing network to a given configuration
+inputs:
+  bootstrap-node-count:
+    description: Number of node services to run on each bootstrap node VM
+  bootstrap-node-vm-count:
+    description: Number of bootstrap node VMs to be deployed
+  network-name:
+    description: The name of the network
+    required: true
+  node-count:
+    description: Number of node services to run on each node VM
+  node-vm-count:
+    description: Number of node VMs to be deployed
+  public-rpc:
+    description: Set to make node manager RPC daemons publicly accessible
+    required: true
+    default: false
+  provider:
+    description: The cloud provider. Accepts 'aws' or 'digital-ocean'.
+    required: true
+  rust-log:
+    description: Set RUST_LOG to this value for testnet-deploy
+    required: false
+  uploader-vm-count:
+    description: Number of uploader VMs to be deployed
+
+runs:
+  using: composite
+  steps:
+    - name: upscale network
+      env:
+        DESIRED_BOOTSTRAP_NODE_COUNT: ${{ inputs.bootstrap-node-count }}
+        DESIRED_BOOTSTRAP_NODE_VM_COUNT: ${{ inputs.bootstrap-node-vm-count }}
+        DESIRED_NODE_COUNT: ${{ inputs.node-count }}
+        DESIRED_NODE_VM_COUNT: ${{ inputs.node-vm-count }}
+        DESIRED_UPLOADER_VM_COUNT: ${{ inputs.uploader-vm-count }}
+        NETWORK_NAME: ${{ inputs.network-name }}
+        PROVIDER: ${{ inputs.provider }}
+        PUBLIC_RPC: ${{ inputs.public-rpc }}
+        RUST_LOG: ${{ inputs.rust-log }}
+      shell: bash
+      run: |
+        set -e
+
+        cd sn-testnet-deploy
+        command="testnet-deploy upscale \
+          --name $NETWORK_NAME \
+          --provider $PROVIDER "
+        [[ -n $DESIRED_BOOTSTRAP_NODE_COUNT ]] && command="$command --desired-bootstrap-node-count $DESIRED_BOOTSTRAP_NODE_COUNT "
+        [[ -n $DESIRED_BOOTSTRAP_NODE_VM_COUNT ]] && command="$command --desired-bootstrap-node-vm-count $DESIRED_BOOTSTRAP_NODE_VM_COUNT "
+        [[ -n $DESIRED_NODE_COUNT ]] && command="$command --desired-node-count $DESIRED_NODE_COUNT "
+        [[ -n $DESIRED_NODE_VM_COUNT ]] && command="$command --desired-node-vm-count $DESIRED_NODE_VM_COUNT "
+        [[ -n $DESIRED_UPLOADER_VM_COUNT ]] && command="$command --desired-uploader-vm-count $DESIRED_UPLOADER_VM_COUNT "
+        [[ $PUBLIC_RPC == "true" ]] && command="$command --public-rpc "
+
+        echo "Will run testnet-deploy with: $command"
+        eval $command


### PR DESCRIPTION
We can arrange multiple actions within one repository. In this initial commit, several are merged from different repositories:

* Initialise the testnet-deploy tool
* Launch a network
* Destroy a network
* Upscale a network
* Upgrade Telegraf configuration
* Upgrade node manager
* Upgrade network
* Stop Telegraf
* Start nodes
* Print inventory
* Network status