### PR TITLE
feat: provide actions for controlling the faucet

### DIFF
--- a/start-faucet/action.yml
+++ b/start-faucet/action.yml
@@ -1,0 +1,19 @@
+name: Start Faucet
+description: Use testnet-deploy to stop the faucet for the environment
+inputs:
+  network-name:
+    description: The name of the network
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: start faucet
+      env:
+        NETWORK_NAME: ${{ inputs.network-name }}
+      shell: bash
+      run: |
+        set -e
+
+        cd sn-testnet-deploy
+        testnet-deploy faucet stop --name $NETWORK_NAME

--- a/stop-faucet/action.yml
+++ b/stop-faucet/action.yml
@@ -1,0 +1,19 @@
+name: Stop Faucet
+description: Use testnet-deploy to stop the faucet for the environment
+inputs:
+  network-name:
+    description: The name of the network
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: stop faucet
+      env:
+        NETWORK_NAME: ${{ inputs.network-name }}
+      shell: bash
+      run: |
+        set -e
+
+        cd sn-testnet-deploy
+        testnet-deploy faucet stop --name $NETWORK_NAME


### PR DESCRIPTION
These will use new `testnet-deploy` commands for starting and stopping the faucet.