### PR TITLE
feat: provide `upgrade-uploader-telegraf-config` action

### DIFF
--- a/upgrade-node-telegraf-config/action.yml
+++ b/upgrade-node-telegraf-config/action.yml
@@ -1,4 +1,4 @@
-name: Upgrade Telegraf Config
+name: Upgrade Node Telegraf Config
 description: Pull the latest Telegraf configuration from the network-dashboards repository
 inputs:
   ansible-forks:
@@ -24,7 +24,7 @@ runs:
         set -e
 
         cd sn-testnet-deploy
-        command="testnet-deploy upgrade-telegraf --name $NETWORK_NAME "
+        command="testnet-deploy upgrade-node-telegraf-config --name $NETWORK_NAME "
         [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose "
         [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
 

--- a/upgrade-uploader-telegraf-config/action.yml
+++ b/upgrade-uploader-telegraf-config/action.yml
@@ -1,4 +1,4 @@
-name: Upgrade Node Telegraf Config
+name: Upgrade Uploader Telegraf Config
 description: Pull the latest Telegraf configuration from the network-dashboards repository
 inputs:
   ansible-forks:
@@ -22,7 +22,7 @@ runs:
         set -e
 
         cd sn-testnet-deploy
-        command="testnet-deploy upgrade-node-telegraf-config --name $NETWORK_NAME "
+        command="testnet-deploy upgrade-uploader-telegraf-config --name $NETWORK_NAME "
         [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose "
         [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
 


### PR DESCRIPTION
- 294835c **refactor: rename `upgrade-telegraf-config` action**

  We are going to introduce a new action, specifically for upgrading the uploader configuration, so we
  need to rename this one to be less generic.

- 8287b06 **feat: provide `upgrade-uploader-telegraf-config` action**

  This will use a new `testnet-deploy` command to upload the Telegraf config for the uploaders.
