### PR TITLE
feat: provide `uploaders-count` inputs

### DIFF
--- a/launch-network/action.yml
+++ b/launch-network/action.yml
@@ -81,6 +81,8 @@ inputs:
       will use these binaries.
   sn-auditor-version:
     description: Supply a version for the sn-auditor. Otherwise the latest will be used.
+  uploaders-count:
+    description: Number of uploaders to run per VM
   uploader-vm-count:
     description: Number of uploader VMs to be deployed
 
@@ -123,6 +125,7 @@ runs:
         SAFENODE_MANAGER_VERSION: ${{ inputs.safenode-manager-version }}
         SAFENODE_VERSION: ${{ inputs.safenode-version }}
         SN_AUDITOR_VERSION: ${{ inputs.sn-auditor-version }}
+        UPLOADERS_COUNT: ${{ inputs.uploaders-count }}
         UPLOADER_VM_COUNT: ${{ inputs.uploader-vm-count }}
       shell: bash
       run: |
@@ -158,11 +161,12 @@ runs:
         [[ $PUBLIC_RPC == "true" ]] && command="$command --public-rpc "
         [[ -n $SAFE_NETWORK_BRANCH ]] && command="$command --branch $SAFE_NETWORK_BRANCH "
         [[ -n $SAFE_NETWORK_USER ]] && command="$command --repo-owner $SAFE_NETWORK_USER "
-        [[ -n $SAFE_VERSION ]] && command="$command --safe-version $SAFE_VERSION "
         [[ -n $SAFENODE_FEATURES ]] && command="$command --safenode-features $SAFENODE_FEATURES "
+        [[ -n $SAFE_VERSION ]] && command="$command --safe-version $SAFE_VERSION "
         [[ -n $SAFENODE_MANAGER_VERSION ]] && command="$command --safenode-manager-version $SAFENODE_MANAGER_VERSION "
         [[ -n $SAFENODE_VERSION ]] && command="$command --safenode-version $SAFENODE_VERSION "
         [[ -n $SN_AUDITOR_VERSION ]] && command="$command --sn-auditor-version $SN_AUDITOR_VERSION "
+        [[ -n $UPLOADER_COUNT ]] && command="$command --uploaders-count $UPLOADER_COUNT "
         [[ -n $UPLOADER_VM_COUNT ]] && command="$command --uploader-vm-count $UPLOADER_VM_COUNT "
 
         echo "Will run testnet-deploy with: $command"

--- a/upscale-network/action.yml
+++ b/upscale-network/action.yml
@@ -46,6 +46,8 @@ inputs:
       Provide the version of safe to use with any new uploaders.
       This value must be supplied when `uploader-vm-count` is used.
     required: false
+  uploaders-count:
+    description: Number of uploaders to run per VM
   uploader-vm-count:
     description: Number of uploader VMs to be deployed
 
@@ -61,6 +63,7 @@ runs:
         DESIRED_NODE_VM_COUNT: ${{ inputs.node-vm-count }}
         DESIRED_PRIVATE_NODE_COUNT: ${{ inputs.private-node-count }}
         DESIRED_PRIVATE_NODE_VM_COUNT: ${{ inputs.private-node-vm-count }}
+        DESIRED_UPLOADERS_COUNT: ${{ inputs.uploaders-count }}
         DESIRED_UPLOADER_VM_COUNT: ${{ inputs.uploader-vm-count }}
         DOWNLOADERS_COUNT: ${{ inputs.downloaders-count }}
         INFRA_ONLY: ${{ inputs.infra-only }}
@@ -87,6 +90,7 @@ runs:
         [[ -n $DESIRED_NODE_VM_COUNT ]] && command="$command --desired-node-vm-count $DESIRED_NODE_VM_COUNT "
         [[ -n $DESIRED_PRIVATE_NODE_COUNT ]] && command="$command --desired-private-node-count $DESIRED_PRIVATE_NODE_COUNT "
         [[ -n $DESIRED_PRIVATE_NODE_VM_COUNT ]] && command="$command --desired-private-node-vm-count $DESIRED_PRIVATE_NODE_VM_COUNT "
+        [[ -n $DESIRED_UPLOADERS_COUNT ]] && command="$command --desired-uploaders-count $DESIRED_UPLOADERS_COUNT "
         [[ -n $DESIRED_UPLOADER_VM_COUNT ]] && command="$command --desired-uploader-vm-count $DESIRED_UPLOADER_VM_COUNT "
         [[ -n $DOWNLOADERS_COUNT ]] && command="$command --downloaders-count $DOWNLOADERS_COUNT "
         [[ $INFRA_ONLY == "true" ]] && command="$command --infra-only "


### PR DESCRIPTION
Allows us to pass a value for the `--desired-uploaders-count` argument on the `upscale` command and the `uploaders-count` argument on the `deploy` command.