### PR TITLE
More Changes to Support EVM-based Networks

### DIFF
--- a/start-nodes/action.yml
+++ b/start-nodes/action.yml
@@ -3,6 +3,8 @@ description: Use testnet-deploy to start all nodes for a deployment
 inputs:
   ansible-forks:
     description: The number of forks, or parallel connections, to use with Ansible. Defaults to 50.
+  interval:
+    description: An interval to be applied between starting the nodes. Value is in milliseconds.
   network-name:
     description: The name of the network
     required: true
@@ -13,6 +15,7 @@ runs:
     - name: start
       env:
         ANSIBLE_FORKS: ${{ inputs.ansible-forks }}
+        INTERVAL: ${{ inputs.interval }}
         NETWORK_NAME: ${{ inputs.network-name }}
       shell: bash
       run: |
@@ -21,6 +24,7 @@ runs:
         cd sn-testnet-deploy
         command="testnet-deploy start --name $NETWORK_NAME "
         [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
+        [[ -n $INTERVAL ]] && command="$command --interval $INTERVAL "
 
         echo "Will run testnet-deploy with: $command"
         eval $command

--- a/upgrade-network/action.yml
+++ b/upgrade-network/action.yml
@@ -16,7 +16,7 @@ inputs:
   network-name:
     description: The name of the network to upgrade
     required: true
-  safenode-version:
+  version:
     description: >
       The safenode version to upgrade to. If not supplied, `testnet-deploy` will use the latest
       version.
@@ -32,7 +32,7 @@ runs:
         CUSTOM_INVENTORY: ${{ inputs.custom-inventory }}
         INTERVAL: ${{ inputs.interval }}
         NETWORK_NAME: ${{ inputs.network-name }}
-        SAFENODE_VERSION: ${{ inputs.safenode-version }}
+        VERSION: ${{ inputs.version }}
       shell: bash
       run: |
         set -e
@@ -42,7 +42,7 @@ runs:
         [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose "
         [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
         [[ -n $INTERVAL ]] && command="$command --interval $INTERVAL "
-        [[ -n $SAFENODE_VERSION ]] && command="$command --safenode-version $SAFENODE_VERSION "
+        [[ -n $VERSION ]] && command="$command --version $VERSION "
 
         if [[ -n $CUSTOM_INVENTORY ]]; then
           IFS=',' read -ra VM_NAMES <<< "$CUSTOM_INVENTORY"

--- a/upgrade-network/action.yml
+++ b/upgrade-network/action.yml
@@ -11,10 +11,6 @@ inputs:
     description: >
       Run the upgrade against particular VMs in the environment.
       Should be a comma-separated list.
-  faucet-version:
-    description: >
-      The faucet version to upgrade to. If not supplied, `testnet-deploy` will use the latest
-      version.
   interval:
     description: The interval to apply between each node upgrade. Units are ms. The default is 200.
   network-name:
@@ -23,10 +19,6 @@ inputs:
   safenode-version:
     description: >
       The safenode version to upgrade to. If not supplied, `testnet-deploy` will use the latest
-      version.
-  sn-auditor-version:
-    description: >
-      The auditor version to upgrade to. If not supplied, `testnet-deploy` will use the latest
       version.
 
 runs:
@@ -38,13 +30,9 @@ runs:
         ANSIBLE_VERBOSE: ${{ inputs.ansible-verbose }}
         AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
         CUSTOM_INVENTORY: ${{ inputs.custom-inventory }}
-        FAUCET_VERSION: ${{ inputs.faucet-version }}
         INTERVAL: ${{ inputs.interval }}
         NETWORK_NAME: ${{ inputs.network-name }}
         SAFENODE_VERSION: ${{ inputs.safenode-version }}
-        # The auditor argument won't be used for now. It is not available on the `upgrade` command
-        # yet, and the auditor upgrade could well be a separate command.
-        SN_AUDITOR_VERSION: ${{ inputs.sn-auditor-version }}
       shell: bash
       run: |
         set -e
@@ -53,7 +41,6 @@ runs:
         command="testnet-deploy upgrade --name $NETWORK_NAME "
         [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose "
         [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
-        [[ -n $FAUCET_VERSION ]] && command="$command --faucet-version $FAUCET_VERSION "
         [[ -n $INTERVAL ]] && command="$command --interval $INTERVAL "
         [[ -n $SAFENODE_VERSION ]] && command="$command --safenode-version $SAFENODE_VERSION "
 

--- a/upgrade-uploaders/action.yml
+++ b/upgrade-uploaders/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   version:
     description: >
-      The version of safe to use. If not supplied, the latest stable version will be used.
+      The version of autonomi to use. If not supplied, the latest stable version will be used.
 
 runs:
   using: composite
@@ -19,4 +19,8 @@ runs:
         set -e
 
         cd sn-testnet-deploy
-        testnet-deploy uploaders upgrade --name $NETWORK_NAME
+        command="testnet-deploy uploaders upgrade --name $NETWORK_NAME "
+        [[ -n $VERSION ]] && command="$command --version $VERSION "
+
+        echo "Will run testnet-deploy with: $command"
+        eval $command


### PR DESCRIPTION
- 1028447 **chore: remove faucet and auditor inputs**

  These components are no longer part of the network.

- af6e927 **chore: rename `safenode-version` input to `version`**

  Now that the faucet doesn't exist, there is no need to qualify the version.

- 57bbe7d **fix: use the `--version` argument**

  The `Upgrade Uploaders` workflow was not actually applying this argument.

- 51c1a83 **feat: provide `interval` arg**

  The `start` command now supports this.