### PR TITLE
feat: provide `interval` inputs on various actions

### DIFF
--- a/bootstrap-network/action.yml
+++ b/bootstrap-network/action.yml
@@ -31,6 +31,8 @@ inputs:
     description: Optionally set the foundation public key for a custom safenode binary.
   genesis-pk:
     description: Optionally set the genesis public key for a custom safenode binary.
+  interval:
+    description: The interval to apply between each node startup. Units are ms. The default is 200.
   log-format:
     description: Set the log format for the nodes, can be 'json' or 'default'. Defaults to 'default' if not set.
   max-archived-log-files:
@@ -76,7 +78,7 @@ inputs:
   safenode-manager-version:
     description: Supply a version for safenode-manager. Otherwise the latest will be used.
   safenode-version:
-    description: Supply a version for safenode. Otherwise the latest will be used.</edit>
+    description: Supply a version for safenode. Otherwise the latest will be used.
 
 runs:
   using: composite
@@ -95,6 +97,7 @@ runs:
         EVM_RPC_URL: ${{ inputs.evm-rpc-url }}
         FOUNDATION_PK: ${{ inputs.foundation-pk }}
         GENESIS_PK: ${{ inputs.genesis-pk }}
+        INTERVAL: ${{ inputs.interval }}
         LOG_FORMAT: ${{ inputs.log-format }}
         MAX_ARCHIVED_LOG_FILES: ${{ inputs.max-archived-log-files }}
         MAX_LOG_FILES: ${{ inputs.max-log-files }}
@@ -136,6 +139,7 @@ runs:
         [[ -n $EVM_RPC_URL ]] && command="$command --evm-rpc-url $EVM_RPC_URL "
         [[ -n $FOUNDATION_PK ]] && command="$command --foundation-pk $FOUNDATION_PK "
         [[ -n $GENESIS_PK ]] && command="$command --genesis-pk $GENESIS_PK "
+        [[ -n $INTERVAL ]] && command="$command --interval $INTERVAL "
         [[ -n $LOG_FORMAT ]] && command="$command --log-format $LOG_FORMAT "
         [[ -n $MAX_ARCHIVED_LOG_FILES ]] && command="$command --max-archived-log-files $MAX_ARCHIVED_LOG_FILES "
         [[ -n $MAX_LOG_FILES ]] && command="$command --max-log-files $MAX_LOG_FILES "

--- a/launch-network/action.yml
+++ b/launch-network/action.yml
@@ -36,6 +36,8 @@ inputs:
     description: Optionally set the foundation public key for a custom safenode binary.
   genesis-pk:
     description: Optionally set the genesis public key for a custom safenode binary.
+  interval:
+    description: The interval to apply between each node startup. Units are ms. The default is 200.
   log-format:
     description: Set the log format for the nodes, can be 'json' or 'default'. Defaults to 'default' if not set.
   max-archived-log-files:
@@ -118,6 +120,7 @@ runs:
         EVM_NODE_VM_SIZE: ${{ inputs.evm-node-vm-size }}
         FOUNDATION_PK: ${{ inputs.foundation-pk }}
         GENESIS_PK: ${{ inputs.genesis-pk }}
+        INTERVAL: ${{ inputs.interval }}
         LOG_FORMAT: ${{ inputs.log-format }}
         MAX_ARCHIVED_LOG_FILES: ${{ inputs.max-archived-log-files }}
         MAX_LOG_FILES: ${{ inputs.max-log-files }}
@@ -165,6 +168,7 @@ runs:
         [[ -n $EVM_NODE_VM_SIZE ]] && command="$command --evm-node-vm-size $EVM_NODE_VM_SIZE "
         [[ -n $FOUNDATION_PK ]] && command="$command --foundation-pk $FOUNDATION_PK "
         [[ -n $GENESIS_PK ]] && command="$command --genesis-pk $GENESIS_PK "
+        [[ -n $INTERVAL ]] && command="$command --interval $INTERVAL "
         [[ -n $LOG_FORMAT ]] && command="$command --log-format $LOG_FORMAT "
         [[ -n $MAX_ARCHIVED_LOG_FILES ]] && command="$command --max-archived-log-files $MAX_ARCHIVED_LOG_FILES "
         [[ -n $MAX_LOG_FILES ]] && command="$command --max-log-files $MAX_LOG_FILES "

--- a/upscale-network/action.yml
+++ b/upscale-network/action.yml
@@ -18,6 +18,8 @@ inputs:
   infra-only:
     description: Only run the terraform part to upscale the machines
     default: false
+  interval:
+    description: The interval to apply between each node upgrade. Units are ms. The default is 200.
   max-log-files:
     description: Maximum number of log files to keep for each service
   max-archived-log-files:
@@ -68,6 +70,7 @@ runs:
         DESIRED_UPLOADER_VM_COUNT: ${{ inputs.uploader-vm-count }}
         DOWNLOADERS_COUNT: ${{ inputs.downloaders-count }}
         INFRA_ONLY: ${{ inputs.infra-only }}
+        INTERVAL: ${{ inputs.interval }}
         MAX_ARCHIVED_LOG_FILES: ${{ inputs.max-archived-log-files }}
         MAX_LOG_FILES: ${{ inputs.max-log-files }}
         NETWORK_NAME: ${{ inputs.network-name }}
@@ -94,6 +97,7 @@ runs:
         [[ -n $DESIRED_UPLOADER_VM_COUNT ]] && command="$command --desired-uploader-vm-count $DESIRED_UPLOADER_VM_COUNT "
         [[ -n $DOWNLOADERS_COUNT ]] && command="$command --downloaders-count $DOWNLOADERS_COUNT "
         [[ $INFRA_ONLY == "true" ]] && command="$command --infra-only "
+        [[ -n $INTERVAL ]] && command="$command --interval $INTERVAL "
         [[ -n $MAX_ARCHIVED_LOG_FILES ]] && command="$command --max-archived-log-files $MAX_ARCHIVED_LOG_FILES "
         [[ -n $MAX_LOG_FILES ]] && command="$command --max-log-files $MAX_LOG_FILES "
         [[ $PLAN == "true" ]] && command="$command --plan "

--- a/upscale-network/action.yml
+++ b/upscale-network/action.yml
@@ -1,8 +1,6 @@
 name: Upscale Network
 description: Upscale an existing network to a given configuration
 inputs:
-  auditor-vm-count:
-    description: Number of auditor VMs to be deployed
   autonomi-version:
     description: >
       Provide the version of autonomi to use with any new uploaders.
@@ -59,7 +57,6 @@ runs:
     - name: upscale network
       env:
         AUTONOMI_VERSION: ${{ inputs.autonomi-version }}
-        DESIRED_AUDITOR_VM_COUNT: ${{ inputs.auditor-vm-count }}
         DESIRED_BOOTSTRAP_NODE_COUNT: ${{ inputs.bootstrap-node-count }}
         DESIRED_BOOTSTRAP_NODE_VM_COUNT: ${{ inputs.bootstrap-node-vm-count }}
         DESIRED_NODE_COUNT: ${{ inputs.node-count }}
@@ -86,16 +83,15 @@ runs:
         command="testnet-deploy upscale \
           --name $NETWORK_NAME \
           --provider $PROVIDER "
-        [[ -n $DESIRED_AUDITOR_VM_COUNT ]] && command="$command --desired-auditor-vm-count $DESIRED_AUDITOR_VM_COUNT "
-        [[ -n $DESIRED_BOOTSTRAP_NODE_COUNT ]] && command="$command --desired-bootstrap-node-count $DESIRED_BOOTSTRAP_NODE_COUNT "
-        [[ -n $DESIRED_BOOTSTRAP_NODE_VM_COUNT ]] && command="$command --desired-bootstrap-node-vm-count $DESIRED_BOOTSTRAP_NODE_VM_COUNT "
-        [[ -n $DESIRED_NODE_COUNT ]] && command="$command --desired-node-count $DESIRED_NODE_COUNT "
-        [[ -n $DESIRED_NODE_VM_COUNT ]] && command="$command --desired-node-vm-count $DESIRED_NODE_VM_COUNT "
-        [[ -n $DESIRED_PRIVATE_NODE_COUNT ]] && command="$command --desired-private-node-count $DESIRED_PRIVATE_NODE_COUNT "
-        [[ -n $DESIRED_PRIVATE_NODE_VM_COUNT ]] && command="$command --desired-private-node-vm-count $DESIRED_PRIVATE_NODE_VM_COUNT "
-        [[ -n $DESIRED_UPLOADERS_COUNT ]] && command="$command --desired-uploaders-count $DESIRED_UPLOADERS_COUNT "
-        [[ -n $DESIRED_UPLOADER_VM_COUNT ]] && command="$command --desired-uploader-vm-count $DESIRED_UPLOADER_VM_COUNT "
-        [[ -n $DOWNLOADERS_COUNT ]] && command="$command --downloaders-count $DOWNLOADERS_COUNT "
+        [[ -n $DESIRED_BOOTSTRAP_NODE_COUNT && $DESIRED_BOOTSTRAP_NODE_COUNT != "0" ]] && command="$command --desired-bootstrap-node-count $DESIRED_BOOTSTRAP_NODE_COUNT "
+        [[ -n $DESIRED_BOOTSTRAP_NODE_VM_COUNT && $DESIRED_BOOTSTRAP_NODE_VM_COUNT != "0" ]] && command="$command --desired-bootstrap-node-vm-count $DESIRED_BOOTSTRAP_NODE_VM_COUNT "
+        [[ -n $DESIRED_NODE_COUNT && $DESIRED_NODE_COUNT != "0" ]] && command="$command --desired-node-count $DESIRED_NODE_COUNT "
+        [[ -n $DESIRED_NODE_VM_COUNT && $DESIRED_NODE_VM_COUNT != "0" ]] && command="$command --desired-node-vm-count $DESIRED_NODE_VM_COUNT "
+        [[ -n $DESIRED_PRIVATE_NODE_COUNT && $DESIRED_PRIVATE_NODE_COUNT != "0" ]] && command="$command --desired-private-node-count $DESIRED_PRIVATE_NODE_COUNT "
+        [[ -n $DESIRED_PRIVATE_NODE_VM_COUNT && $DESIRED_PRIVATE_NODE_VM_COUNT != "0" ]] && command="$command --desired-private-node-vm-count $DESIRED_PRIVATE_NODE_VM_COUNT "
+        [[ -n $DESIRED_UPLOADERS_COUNT && $DESIRED_UPLOADERS_COUNT != "0" ]] && command="$command --desired-uploaders-count $DESIRED_UPLOADERS_COUNT "
+        [[ -n $DESIRED_UPLOADER_VM_COUNT && $DESIRED_UPLOADER_VM_COUNT != "0" ]] && command="$command --desired-uploader-vm-count $DESIRED_UPLOADER_VM_COUNT "
+        [[ -n $DOWNLOADERS_COUNT && $DOWNLOADERS_COUNT != "0" ]] && command="$command --downloaders-count $DOWNLOADERS_COUNT "
         [[ $INFRA_ONLY == "true" ]] && command="$command --infra-only "
         [[ -n $INTERVAL ]] && command="$command --interval $INTERVAL "
         [[ -n $MAX_ARCHIVED_LOG_FILES ]] && command="$command --max-archived-log-files $MAX_ARCHIVED_LOG_FILES "


### PR DESCRIPTION
- 8c25197 **feat: provide `interval` inputs on various actions**

  The `testnet-deploy` tool now supports an interval on these commands.

- 4bf3c58 **fix: only use non-zero counts**

  The counts should not be used if they are set to 0.

  Downscaling would not be a legitimate operation anyway.
