### PR TITLE
Various Changes to Support Rebranding

### DIFF
--- a/bootstrap-network/action.yml
+++ b/bootstrap-network/action.yml
@@ -6,6 +6,19 @@ inputs:
   ansible-verbose:
     description: Set to use verbose output for Ansible
     default: false
+  antctl-version:
+    description: Supply a version for antctl. Otherwise the latest will be used.
+  antnode-features:
+    description: Comma-separated list of features to be used when building a branch of antnode
+  antnode-version:
+    description: Supply a version for antnode. Otherwise the latest will be used.
+  autonomi-branch:
+    description: >
+      Build binaries from the specified autonomi branch. The testnet will use these binaries.
+  autonomi-repo-owner:
+    description: >
+      Build binaries from the autonomi repository owned by this org or username. The testnet
+      will use these binaries.
   chunk-size:
     description: The size of chunks in bytes for data storage
   environment-type:
@@ -17,8 +30,6 @@ inputs:
     description: Pass a comma-separated list of environment variables to safenode services
   evm-data-payments-address:
     description: The address of the EVM data payments contract
-  evm-deployer-wallet-private-key:
-    description: The private key of the wallet used for EVM contract deployment
   evm-network-type:
     description: >
       The type of EVM network to use. Possible values are 'arbitrum-one', 'arbitrum-sepolia', or 'custom'.
@@ -27,10 +38,6 @@ inputs:
     description: The address of the EVM payment token contract
   evm-rpc-url:
     description: The RPC URL for the EVM network
-  foundation-pk:
-    description: Optionally set the foundation public key for a custom safenode binary.
-  genesis-pk:
-    description: Optionally set the genesis public key for a custom safenode binary.
   interval:
     description: The interval to apply between each node startup. Units are ms. The default is 200.
   log-format:
@@ -44,16 +51,12 @@ inputs:
   network-name:
     description: The name of the testnet.
     required: true
-  network-royalties-pk:
-    description: Optionally set the network royalties public key for a custom safenode binary.
   node-count:
     description: Number of node services to run on each node VM
   node-vm-count:
     description: Number of node VMs to be deployed
   node-vm-size:
     description: The size of the regular node VMs
-  payment-forward-pk:
-    description: Optionally set the payment forward public key for a custom safenode binary.
   peer:
     description: A peer from the network to bootstrap from. Should be in multiaddr format.
     required: true
@@ -66,19 +69,6 @@ inputs:
     required: true
   rewards-address:
     description: The address for receiving network rewards
-  safe-network-branch:
-    description: >
-      Build binaries from the specified safe_network branch. The testnet will use these binaries.
-  safe-network-user:
-    description: >
-      Build binaries from the safe_network repository owned by this org or username. The testnet
-      will use these binaries.
-  safenode-features:
-    description: Comma-separated list of features to be used when building a branch of safenode
-  safenode-manager-version:
-    description: Supply a version for safenode-manager. Otherwise the latest will be used.
-  safenode-version:
-    description: Supply a version for safenode. Otherwise the latest will be used.
 
 runs:
   using: composite
@@ -87,37 +77,32 @@ runs:
       env:
         ANSIBLE_FORKS: ${{ inputs.ansible-forks }}
         ANSIBLE_VERBOSE: ${{ inputs.ansible-verbose }}
+        ANTCTL_VERSION: ${{ inputs.antctl-version }}
+        ANTNODE_FEATURES: ${{ inputs.antnode-features }}
+        ANTNODE_VERSION: ${{ inputs.antnode-version }}
+        AUTONOMI_BRANCH: ${{ inputs.autonomi-branch }}
+        AUTONOMI_REPO_OWNER: ${{ inputs.autonomi-repo-owner }}
         CHUNK_SIZE: ${{ inputs.chunk-size }}
         ENVIRONMENT_TYPE: ${{ inputs.environment-type }}
         ENVIRONMENT_VARS: ${{ inputs.environment-vars }}
         EVM_DATA_PAYMENTS_ADDRESS: ${{ inputs.evm-data-payments-address }}
-        EVM_DEPLOYER_WALLET_PRIVATE_KEY: ${{ inputs.evm-deployer-wallet-private-key }}
         EVM_NETWORK_TYPE: ${{ inputs.evm-network-type }}
         EVM_PAYMENT_TOKEN_ADDRESS: ${{ inputs.evm-payment-token-address }}
         EVM_RPC_URL: ${{ inputs.evm-rpc-url }}
-        FOUNDATION_PK: ${{ inputs.foundation-pk }}
-        GENESIS_PK: ${{ inputs.genesis-pk }}
         INTERVAL: ${{ inputs.interval }}
         LOG_FORMAT: ${{ inputs.log-format }}
         MAX_ARCHIVED_LOG_FILES: ${{ inputs.max-archived-log-files }}
         MAX_LOG_FILES: ${{ inputs.max-log-files }}
         NETWORK_CONTACTS_FILE_NAME: ${{ inputs.network-contacts-file-name }}
         NETWORK_NAME: ${{ inputs.network-name }}
-        NETWORK_ROYALTIES_PK: ${{ inputs.network-royalties-pk }}
         NODE_COUNT: ${{ inputs.node-count }}
         NODE_VM_COUNT: ${{ inputs.node-vm-count }}
         NODE_VM_SIZE: ${{ inputs.node-vm-size }}
-        PAYMENT_FORWARD_PK: ${{ inputs.payment-forward-pk }}
         PEER: ${{ inputs.peer }}
         PRIVATE_NODE_COUNT: ${{ inputs.private-node-count }}
         PRIVATE_NODE_VM_COUNT: ${{ inputs.private-node-vm-count }}
         PROVIDER: ${{ inputs.provider }}
         REWARDS_ADDRESS: ${{ inputs.rewards-address }}
-        SAFE_NETWORK_BRANCH: ${{ inputs.safe-network-branch }}
-        SAFE_NETWORK_USER: ${{ inputs.safe-network-user }}
-        SAFENODE_FEATURES: ${{ inputs.safenode-features }}
-        SAFENODE_MANAGER_VERSION: ${{ inputs.safenode-manager-version }}
-        SAFENODE_VERSION: ${{ inputs.safenode-version }}
       shell: bash
       run: |
         set -e
@@ -130,33 +115,28 @@ runs:
           --provider $PROVIDER "
         [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
         [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose "
+        [[ -n $AUTONOMI_BRANCH ]] && command="$command --branch $AUTONOMI_BRANCH "
+        [[ -n $AUTONOMI_REPO_OWNER ]] && command="$command --repo-owner $AUTONOMI_REPO_OWNER "
+        [[ -n $ANTNODE_FEATURES ]] && command="$command --antnode-features $ANTNODE_FEATURES "
+        [[ -n $ANTCTL_VERSION ]] && command="$command --antctl-version $ANTCTL_VERSION "
+        [[ -n $ANTNODE_VERSION ]] && command="$command --antnode-version $ANTNODE_VERSION "
         [[ -n $CHUNK_SIZE ]] && command="$command --chunk-size $CHUNK_SIZE "
         [[ -n $ENVIRONMENT_VARS ]] && command="$command --env $ENVIRONMENT_VARS "
         [[ -n $EVM_DATA_PAYMENTS_ADDRESS ]] && command="$command --evm-data-payments-address $EVM_DATA_PAYMENTS_ADDRESS "
-        [[ -n $EVM_DEPLOYER_WALLET_PRIVATE_KEY ]] && command="$command --evm-deployer-wallet-private-key $EVM_DEPLOYER_WALLET_PRIVATE_KEY "
         [[ -n $EVM_NETWORK_TYPE ]] && command="$command --evm-network-type $EVM_NETWORK_TYPE "
         [[ -n $EVM_PAYMENT_TOKEN_ADDRESS ]] && command="$command --evm-payment-token-address $EVM_PAYMENT_TOKEN_ADDRESS "
         [[ -n $EVM_RPC_URL ]] && command="$command --evm-rpc-url $EVM_RPC_URL "
-        [[ -n $FOUNDATION_PK ]] && command="$command --foundation-pk $FOUNDATION_PK "
-        [[ -n $GENESIS_PK ]] && command="$command --genesis-pk $GENESIS_PK "
         [[ -n $INTERVAL ]] && command="$command --interval $INTERVAL "
         [[ -n $LOG_FORMAT ]] && command="$command --log-format $LOG_FORMAT "
         [[ -n $MAX_ARCHIVED_LOG_FILES ]] && command="$command --max-archived-log-files $MAX_ARCHIVED_LOG_FILES "
         [[ -n $MAX_LOG_FILES ]] && command="$command --max-log-files $MAX_LOG_FILES "
         [[ -n $NETWORK_CONTACTS_FILE_NAME ]] && command="$command --network-contacts-file-name $NETWORK_CONTACTS_FILE_NAME "
-        [[ -n $NETWORK_ROYALTIES_PK ]] && command="$command --network-royalties-pk $NETWORK_ROYALTIES_PK "
         [[ -n $NODE_COUNT ]] && command="$command --node-count $NODE_COUNT "
         [[ -n $NODE_VM_COUNT ]] && command="$command --node-vm-count $NODE_VM_COUNT "
         [[ -n $NODE_VM_SIZE ]] && command="$command --node-vm-size $NODE_VM_SIZE "
-        [[ -n $PAYMENT_FORWARD_PK ]] && command="$command --payment-forward-pk $PAYMENT_FORWARD_PK "
         [[ -n $PRIVATE_NODE_COUNT ]] && command="$command --private-node-count $PRIVATE_NODE_COUNT "
         [[ -n $PRIVATE_NODE_VM_COUNT ]] && command="$command --private-node-vm-count $PRIVATE_NODE_VM_COUNT "
         [[ -n $REWARDS_ADDRESS ]] && command="$command --rewards-address $REWARDS_ADDRESS "
-        [[ -n $SAFE_NETWORK_BRANCH ]] && command="$command --branch $SAFE_NETWORK_BRANCH "
-        [[ -n $SAFE_NETWORK_USER ]] && command="$command --repo-owner $SAFE_NETWORK_USER "
-        [[ -n $SAFENODE_FEATURES ]] && command="$command --safenode-features $SAFENODE_FEATURES "
-        [[ -n $SAFENODE_MANAGER_VERSION ]] && command="$command --safenode-manager-version $SAFENODE_MANAGER_VERSION "
-        [[ -n $SAFENODE_VERSION ]] && command="$command --safenode-version $SAFENODE_VERSION "
 
         echo "Will run testnet-deploy with: $command"
         eval $command

--- a/launch-network/action.yml
+++ b/launch-network/action.yml
@@ -21,12 +21,6 @@ inputs:
     description: >
       Build binaries from the autonomi repository owned by this org or username. The testnet
       will use these binaries.
-  bootstrap-node-count:
-    description: Number of node services to run on each bootstrap node VM
-  bootstrap-node-vm-count:
-    description: Number of bootstrap node VMs to be deployed
-  bootstrap-node-vm-size:
-    description: The size of the bootstrap node VMs
   chunk-size:
     description: >
       Specify the chunk size in bytes as a 64-bit integer.
@@ -53,10 +47,6 @@ inputs:
     description: The address of the EVM payment token contract
   evm-rpc-url:
     description: The RPC URL for the EVM network when using a custom network type
-  foundation-pk:
-    description: Optionally set the foundation public key for a custom safenode binary.
-  genesis-pk:
-    description: Optionally set the genesis public key for a custom safenode binary.
   interval:
     description: The interval to apply between each node startup. Units are ms. The default is 200.
   log-format:
@@ -67,23 +57,36 @@ inputs:
     description: Maximum number of log files to keep for each service
   network-contacts-file-name:
     description: Provide a name for the network contacts file
+  network-id:
+    description: The network ID (must be between 2 and 255)
+    type: number
+    minimum: 2
+    maximum: 255
   network-name:
     description: The name of the testnet.
     required: true
-  network-royalties-pk:
-    description: Optionally set the network royalties public key for a custom safenode binary.
   node-count:
     description: Number of node services to run on each node VM
   node-vm-count:
     description: Number of node VMs to be deployed
   node-vm-size:
     description: The size of the regular node VMs
-  payment-forward-pk:
-    description: Optionally set the payment forward public key for a custom safenode binary.
+  node-volume-size:
+    description: The size of the volumes for regular node VMs in GB
+  peer-cache-node-count:
+    description: Number of node services to run on each peer cache node VM
+  peer-cache-node-vm-count:
+    description: Number of peer cache node VMs to be deployed
+  peer-cache-node-vm-size:
+    description: The size of the peer cache node VMs
+  peer-cache-node-volume-size:
+    description: The size of the volumes for peer cache node VMs in GB
   private-node-count:
     description: Number of node services to run on each private node VM
   private-node-vm-count:
     description: Number of private node VMs to be deployed
+  private-node-volume-size:
+    description: The size of the volumes for private node VMs in GB
   protocol-version:
     description: The network protocol version can be set to 'restricted' or any custom version string.
   provider:
@@ -120,10 +123,6 @@ runs:
         ANTNODE_VERSION: ${{ inputs.antnode-version }}
         AUTONOMI_BRANCH: ${{ inputs.autonomi-branch }}
         AUTONOMI_REPO_OWNER: ${{ inputs.autonomi-repo-owner }}
-        BETA_ENCRYPTION_KEY: ${{ inputs.beta-encryption-key }}
-        BOOTSTRAP_NODE_COUNT: ${{ inputs.bootstrap-node-count }}
-        BOOTSTRAP_NODE_VM_COUNT: ${{ inputs.bootstrap-node-vm-count }}
-        BOOTSTRAP_NODE_VM_SIZE: ${{ inputs.bootstrap-node-vm-size }}
         CHUNK_SIZE: ${{ inputs.chunk-size }}
         DOWNLOADERS_COUNT: ${{ inputs.downloaders-count }}
         ENVIRONMENT_TYPE: ${{ inputs.environment-type }}
@@ -133,21 +132,24 @@ runs:
         EVM_NODE_VM_SIZE: ${{ inputs.evm-node-vm-size }}
         EVM_PAYMENT_TOKEN_ADDRESS: ${{ inputs.evm-payment-token-address }}
         EVM_RPC_URL: ${{ inputs.evm-rpc-url }}
-        FOUNDATION_PK: ${{ inputs.foundation-pk }}
-        GENESIS_PK: ${{ inputs.genesis-pk }}
         INTERVAL: ${{ inputs.interval }}
         LOG_FORMAT: ${{ inputs.log-format }}
         MAX_ARCHIVED_LOG_FILES: ${{ inputs.max-archived-log-files }}
         MAX_LOG_FILES: ${{ inputs.max-log-files }}
         NETWORK_CONTACTS_FILE_NAME: ${{ inputs.network-contacts-file-name }}
+        NETWORK_ID: ${{ inputs.network-id }}
         NETWORK_NAME: ${{ inputs.network-name }}
-        NETWORK_ROYALTIES_PK: ${{ inputs.network-royalties-pk }}
         NODE_COUNT: ${{ inputs.node-count }}
         NODE_VM_COUNT: ${{ inputs.node-vm-count }}
         NODE_VM_SIZE: ${{ inputs.node-vm-size }}
-        PAYMENT_FORWARD_PK: ${{ inputs.payment-forward-pk }}
+        NODE_VOLUME_SIZE: ${{ inputs.node-volume-size }}
+        PEER_CACHE_NODE_COUNT: ${{ inputs.peer-cache-node-count }}
+        PEER_CACHE_NODE_VM_COUNT: ${{ inputs.peer-cache-node-vm-count }}
+        PEER_CACHE_NODE_VM_SIZE: ${{ inputs.peer-cache-node-vm-size }}
+        PEER_CACHE_NODE_VOLUME_SIZE: ${{ inputs.peer-cache-node-volume-size }}
         PRIVATE_NODE_COUNT: ${{ inputs.private-node-count }}
         PRIVATE_NODE_VM_COUNT: ${{ inputs.private-node-vm-count }}
+        PRIVATE_NODE_VOLUME_SIZE: ${{ inputs.private-node-volume-size }}
         PROTOCOL_VERSION: ${{ inputs.protocol-version }}
         PROVIDER: ${{ inputs.provider }}
         PUBLIC_RPC: ${{ inputs.public-rpc }}
@@ -173,9 +175,6 @@ runs:
         [[ -n $ANTNODE_VERSION ]] && command="$command --antnode-version $ANTNODE_VERSION "
         [[ -n $AUTONOMI_BRANCH ]] && command="$command --branch $AUTONOMI_BRANCH "
         [[ -n $AUTONOMI_REPO_OWNER ]] && command="$command --repo-owner $AUTONOMI_REPO_OWNER "
-        [[ -n $BOOTSTRAP_NODE_COUNT ]] && command="$command --bootstrap-node-count $BOOTSTRAP_NODE_COUNT "
-        [[ -n $BOOTSTRAP_NODE_VM_COUNT ]] && command="$command --bootstrap-node-vm-count $BOOTSTRAP_NODE_VM_COUNT "
-        [[ -n $BOOTSTRAP_NODE_VM_SIZE ]] && command="$command --bootstrap-node-vm-size $BOOTSTRAP_NODE_VM_SIZE "
         [[ -n $CHUNK_SIZE ]] && command="$command --chunk-size $CHUNK_SIZE "
         [[ $DOWNLOADERS_COUNT -gt 0 ]] && command="$command --downloaders-count $DOWNLOADERS_COUNT "
         [[ -n $ENVIRONMENT_VARS ]] && command="$command --env $ENVIRONMENT_VARS "
@@ -184,20 +183,23 @@ runs:
         [[ -n $EVM_NODE_VM_SIZE ]] && command="$command --evm-node-vm-size $EVM_NODE_VM_SIZE "
         [[ -n $EVM_PAYMENT_TOKEN_ADDRESS ]] && command="$command --evm-payment-token-address $EVM_PAYMENT_TOKEN_ADDRESS "
         [[ -n $EVM_RPC_URL ]] && command="$command --evm-rpc-url $EVM_RPC_URL "
-        [[ -n $FOUNDATION_PK ]] && command="$command --foundation-pk $FOUNDATION_PK "
-        [[ -n $GENESIS_PK ]] && command="$command --genesis-pk $GENESIS_PK "
         [[ -n $INTERVAL ]] && command="$command --interval $INTERVAL "
         [[ -n $LOG_FORMAT ]] && command="$command --log-format $LOG_FORMAT "
         [[ -n $MAX_ARCHIVED_LOG_FILES ]] && command="$command --max-archived-log-files $MAX_ARCHIVED_LOG_FILES "
         [[ -n $MAX_LOG_FILES ]] && command="$command --max-log-files $MAX_LOG_FILES "
         [[ -n $NETWORK_CONTACTS_FILE_NAME ]] && command="$command --network-contacts-file-name $NETWORK_CONTACTS_FILE_NAME "
-        [[ -n $NETWORK_ROYALTIES_PK ]] && command="$command --network-royalties-pk $NETWORK_ROYALTIES_PK "
+        [[ -n $NETWORK_ID ]] && command="$command --network-id $NETWORK_ID "
         [[ -n $NODE_COUNT ]] && command="$command --node-count $NODE_COUNT "
         [[ -n $NODE_VM_COUNT ]] && command="$command --node-vm-count $NODE_VM_COUNT "
         [[ -n $NODE_VM_SIZE ]] && command="$command --node-vm-size $NODE_VM_SIZE "
-        [[ -n $PAYMENT_FORWARD_PK ]] && command="$command --payment-forward-pk $PAYMENT_FORWARD_PK "
+        [[ -n $NODE_VOLUME_SIZE ]] && command="$command --node-volume-size $NODE_VOLUME_SIZE "
+        [[ -n $PEER_CACHE_NODE_COUNT ]] && command="$command --peer-cache-node-count $PEER_CACHE_NODE_COUNT "
+        [[ -n $PEER_CACHE_NODE_VM_COUNT ]] && command="$command --peer-cache-node-vm-count $PEER_CACHE_NODE_VM_COUNT "
+        [[ -n $PEER_CACHE_NODE_VM_SIZE ]] && command="$command --peer-cache-node-vm-size $PEER_CACHE_NODE_VM_SIZE "
+        [[ -n $PEER_CACHE_NODE_VOLUME_SIZE ]] && command="$command --peer-cache-node-volume-size $PEER_CACHE_NODE_VOLUME_SIZE "
         [[ -n $PRIVATE_NODE_COUNT ]] && command="$command --private-node-count $PRIVATE_NODE_COUNT "
         [[ -n $PRIVATE_NODE_VM_COUNT ]] && command="$command --private-node-vm-count $PRIVATE_NODE_VM_COUNT "
+        [[ -n $PRIVATE_NODE_VOLUME_SIZE ]] && command="$command --private-node-volume-size $PRIVATE_NODE_VOLUME_SIZE "
         [[ -n $PROTOCOL_VERSION ]] && command="$command --protocol-version $PROTOCOL_VERSION "
         [[ $PUBLIC_RPC == "true" ]] && command="$command --public-rpc "
         [[ -n $REWARDS_ADDRESS ]] && command="$command --rewards-address $REWARDS_ADDRESS "

--- a/launch-network/action.yml
+++ b/launch-network/action.yml
@@ -6,6 +6,21 @@ inputs:
   ansible-verbose:
     description: Set to use verbose output for Ansible
     default: false
+  ant-version:
+    description: Supply a version for ant. Otherwise the latest will be used.
+  antctl-version:
+    description: Supply a version for antctl. Otherwise the latest will be used.
+  antnode-version:
+    description: Supply a version for antnode. Otherwise the latest will be used.
+  antnode-features:
+    description: Comma-separated list of features to be used when building a branch of antnode
+  autonomi-branch:
+    description: >
+      Build binaries from the specified autonomi branch. The testnet will use these binaries.
+  autonomi-repo-owner:
+    description: >
+      Build binaries from the autonomi repository owned by this org or username. The testnet
+      will use these binaries.
   bootstrap-node-count:
     description: Number of node services to run on each bootstrap node VM
   bootstrap-node-vm-count:
@@ -81,21 +96,6 @@ inputs:
   rewards-address:
     description: The rewards address for each safenode service.
     required: true
-  safenode-features:
-    description: Comma-separated list of features to be used when building a branch of safenode
-  safe-version:
-    description: Supply a version for safe. Otherwise the latest will be used.
-  safenode-version:
-    description: Supply a version for safenode. Otherwise the latest will be used.
-  safenode-manager-version:
-    description: Supply a version for safenode-manager. Otherwise the latest will be used.
-  safe-network-branch:
-    description: >
-      Build binaries from the specified safe_network branch. The testnet will use these binaries.
-  safe-network-user:
-    description: >
-      Build binaries from the safe_network repository owned by this org or username. The testnet
-      will use these binaries.
   uploader-vm-count:
     description: Number of uploader VMs to be deployed
   uploader-vm-size:
@@ -114,6 +114,12 @@ runs:
       env:
         ANSIBLE_FORKS: ${{ inputs.ansible-forks }}
         ANSIBLE_VERBOSE: ${{ inputs.ansible-verbose }}
+        ANT_VERSION: ${{ inputs.ant-version }}
+        ANTCTL_VERSION: ${{ inputs.antctl-version }}
+        ANTNODE_FEATURES: ${{ inputs.antnode-features }}
+        ANTNODE_VERSION: ${{ inputs.antnode-version }}
+        AUTONOMI_BRANCH: ${{ inputs.autonomi-branch }}
+        AUTONOMI_REPO_OWNER: ${{ inputs.autonomi-repo-owner }}
         BETA_ENCRYPTION_KEY: ${{ inputs.beta-encryption-key }}
         BOOTSTRAP_NODE_COUNT: ${{ inputs.bootstrap-node-count }}
         BOOTSTRAP_NODE_VM_COUNT: ${{ inputs.bootstrap-node-vm-count }}
@@ -147,12 +153,6 @@ runs:
         PUBLIC_RPC: ${{ inputs.public-rpc }}
         RUST_LOG: ${{ inputs.rust-log }}
         REWARDS_ADDRESS: ${{ inputs.rewards-address }}
-        SAFE_NETWORK_BRANCH: ${{ inputs.safe-network-branch }}
-        SAFE_NETWORK_USER: ${{ inputs.safe-network-user }}
-        SAFE_VERSION: ${{ inputs.safe-version }}
-        SAFENODE_FEATURES: ${{ inputs.safenode-features }}
-        SAFENODE_MANAGER_VERSION: ${{ inputs.safenode-manager-version }}
-        SAFENODE_VERSION: ${{ inputs.safenode-version }}
         UPLOADER_VM_COUNT: ${{ inputs.uploader-vm-count }}
         UPLOADER_VM_SIZE: ${{ inputs.uploader-vm-size }}
         UPLOADERS_COUNT: ${{ inputs.uploaders-count }}
@@ -167,6 +167,12 @@ runs:
           --name $NETWORK_NAME \
           --provider $PROVIDER "
         [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose "
+        [[ -n $ANT_VERSION ]] && command="$command --ant-version $ANT_VERSION "
+        [[ -n $ANTCTL_VERSION ]] && command="$command --antctl-version $ANTCTL_VERSION "
+        [[ -n $ANTNODE_FEATURES ]] && command="$command --antnode-features $ANTNODE_FEATURES "
+        [[ -n $ANTNODE_VERSION ]] && command="$command --antnode-version $ANTNODE_VERSION "
+        [[ -n $AUTONOMI_BRANCH ]] && command="$command --branch $AUTONOMI_BRANCH "
+        [[ -n $AUTONOMI_REPO_OWNER ]] && command="$command --repo-owner $AUTONOMI_REPO_OWNER "
         [[ -n $BOOTSTRAP_NODE_COUNT ]] && command="$command --bootstrap-node-count $BOOTSTRAP_NODE_COUNT "
         [[ -n $BOOTSTRAP_NODE_VM_COUNT ]] && command="$command --bootstrap-node-vm-count $BOOTSTRAP_NODE_VM_COUNT "
         [[ -n $BOOTSTRAP_NODE_VM_SIZE ]] && command="$command --bootstrap-node-vm-size $BOOTSTRAP_NODE_VM_SIZE "
@@ -195,12 +201,6 @@ runs:
         [[ -n $PROTOCOL_VERSION ]] && command="$command --protocol-version $PROTOCOL_VERSION "
         [[ $PUBLIC_RPC == "true" ]] && command="$command --public-rpc "
         [[ -n $REWARDS_ADDRESS ]] && command="$command --rewards-address $REWARDS_ADDRESS "
-        [[ -n $SAFE_NETWORK_BRANCH ]] && command="$command --branch $SAFE_NETWORK_BRANCH "
-        [[ -n $SAFE_NETWORK_USER ]] && command="$command --repo-owner $SAFE_NETWORK_USER "
-        [[ -n $SAFE_VERSION ]] && command="$command --safe-version $SAFE_VERSION "
-        [[ -n $SAFENODE_FEATURES ]] && command="$command --safenode-features $SAFENODE_FEATURES "
-        [[ -n $SAFENODE_MANAGER_VERSION ]] && command="$command --safenode-manager-version $SAFENODE_MANAGER_VERSION "
-        [[ -n $SAFENODE_VERSION ]] && command="$command --safenode-version $SAFENODE_VERSION "
         [[ -n $UPLOADER_VM_COUNT ]] && command="$command --uploader-vm-count $UPLOADER_VM_COUNT "
         [[ -n $UPLOADER_VM_SIZE ]] && command="$command --uploader-vm-size $UPLOADER_VM_SIZE "
         [[ -n $UPLOADERS_COUNT ]] && command="$command --uploaders-count $UPLOADERS_COUNT "
@@ -209,11 +209,11 @@ runs:
         echo "Will run testnet-deploy with: $command"
         eval $command
 
-    - name: Set SAFE_PEERS and SN_INVENTORY
+    - name: Set ANT_PEERS and ANT_INVENTORY
       shell: bash
       run: |
         inventory_path=/home/runner/.local/share/safe/testnet-deploy/"${{ inputs.network-name }}"-inventory.json
         echo "Inventory Path: $inventory_path"
         genesis_multiaddr=$(jq -r '.genesis_multiaddr' $inventory_path)
-        echo "SAFE_PEERS=$genesis_multiaddr" >> $GITHUB_ENV
-        echo "SN_INVENTORY=$inventory_path" >> $GITHUB_ENV
+        echo "ANT_PEERS=$genesis_multiaddr" >> $GITHUB_ENV
+        echo "ANT_INVENTORY=$inventory_path" >> $GITHUB_ENV

--- a/upgrade-antctl/action.yml
+++ b/upgrade-antctl/action.yml
@@ -1,5 +1,5 @@
-name: Upgrade Node Manager
-description: Upgrade the node manager binary on all VMs in the deployment
+name: Upgrade Antctl
+description: Upgrade the antctl binary on all VMs in the deployment
 inputs:
   custom-inventory:
     description: >
@@ -10,16 +10,16 @@ inputs:
     required: true
   node-type:
     description: >
-      Specify the type of node VM to upgrade the node manager on. If not provided, the node manager on
+      Specify the type of node VM to upgrade the antctl on. If not provided, the antctl on
       all the node VMs will be upgraded. Valid values are "bootstrap", "genesis", "generic" and "private".
       Cannot be used with the custom-inventory input.
   version:
-    description: The safenode-manager version to upgrade to
+    description: The antctl version to upgrade to
 
 runs:
   using: composite
   steps:
-    - name: upgrade node manager
+    - name: upgrade antctl
       env:
         CUSTOM_INVENTORY: ${{ inputs.custom-inventory }}
         NETWORK_NAME: ${{ inputs.network-name }}
@@ -30,7 +30,7 @@ runs:
         set -e
 
         cd sn-testnet-deploy
-        command="testnet-deploy upgrade-node-manager --name $NETWORK_NAME "
+        command="testnet-deploy upgrade-antctl --name $NETWORK_NAME "
         [[ -n $VERSION ]] && command="$command --version $VERSION "
         [[ -n $NODE_TYPE ]] && command="$command --node-type $NODE_TYPE "
 

--- a/upgrade-network/action.yml
+++ b/upgrade-network/action.yml
@@ -15,6 +15,9 @@ inputs:
     description: >
       A pre-upgrade delay to apply. Useful for when there is one node per machine.
       Value is in seconds.
+  force:
+    description: >
+      This can be used for downgrading. It will apply the new binary even if the target version is lower.
   interval:
     description: The interval to apply between each node upgrade. Units are ms. The default is 200.
   network-name:
@@ -27,7 +30,7 @@ inputs:
       Cannot be used with the custom-inventory input.
   version:
     description: >
-      The safenode version to upgrade to. If not supplied, `testnet-deploy` will use the latest
+      The antnode version to upgrade to. If not supplied, `testnet-deploy` will use the latest
       version.
 
 runs:
@@ -40,6 +43,7 @@ runs:
         AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
         CUSTOM_INVENTORY: ${{ inputs.custom-inventory }}
         DELAY: ${{ inputs.delay }}
+        FORCE: ${{ inputs.force }}
         INTERVAL: ${{ inputs.interval }}
         NETWORK_NAME: ${{ inputs.network-name }}
         NODE_TYPE: ${{ inputs.node-type }}
@@ -53,9 +57,10 @@ runs:
         [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose "
         [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
         [[ -n $DELAY ]] && command="$command --pre-upgrade-delay $DELAY "
+        [[ $FORCE == "true" ]] && command="$command --force "
         [[ -n $INTERVAL ]] && command="$command --interval $INTERVAL "
-        [[ -n $VERSION ]] && command="$command --version $VERSION "
         [[ -n $NODE_TYPE ]] && command="$command --node-type $NODE_TYPE "
+        [[ -n $VERSION ]] && command="$command --version $VERSION "
 
         if [[ -n $CUSTOM_INVENTORY ]]; then
           IFS=',' read -ra VM_NAMES <<< "$CUSTOM_INVENTORY"

--- a/upscale-network/action.yml
+++ b/upscale-network/action.yml
@@ -1,10 +1,16 @@
 name: Upscale Network
 description: Upscale an existing network to a given configuration
 inputs:
-  autonomi-version:
+  ant-version:
     description: >
       Provide the version of autonomi to use with any new uploaders.
       This value must be supplied when `uploader-vm-count` is used.
+    required: false
+  antctl-version:
+    description: Version of antctl to use for any new nodes
+    required: false
+  antnode-version:
+    description: Version of safenode to use for any new nodes
     required: false
   bootstrap-node-count:
     description: Number of node services to run on each bootstrap node VM
@@ -18,10 +24,10 @@ inputs:
     default: false
   interval:
     description: The interval to apply between each node upgrade. Units are ms. The default is 200.
-  max-log-files:
-    description: Maximum number of log files to keep for each service
   max-archived-log-files:
     description: Maximum number of archived log files to keep for each service
+  max-log-files:
+    description: Maximum number of log files to keep for each service
   network-name:
     description: The name of the network
     required: true
@@ -46,23 +52,19 @@ inputs:
   rust-log:
     description: Set RUST_LOG to this value for testnet-deploy
     required: false
-  safenode-version:
-    description: Version of safenode to use for any new nodes
-    required: false
-  safenode-manager-version:
-    description: Version of safenode-manager to use for any new nodes
-    required: false
-  uploaders-count:
-    description: Number of uploaders to run per VM
   uploader-vm-count:
     description: Number of uploader VMs to be deployed
+  uploaders-count:
+    description: Number of uploaders to run per VM
 
 runs:
   using: composite
   steps:
     - name: upscale network
       env:
-        AUTONOMI_VERSION: ${{ inputs.autonomi-version }}
+        ANT_VERSION: ${{ inputs.ant-version }}
+        ANTCTL_VERSION: ${{ inputs.antctl-version }}
+        ANTNODE_VERSION: ${{ inputs.antnode-version }}
         DESIRED_BOOTSTRAP_NODE_COUNT: ${{ inputs.bootstrap-node-count }}
         DESIRED_BOOTSTRAP_NODE_VM_COUNT: ${{ inputs.bootstrap-node-vm-count }}
         DESIRED_NODE_COUNT: ${{ inputs.node-count }}
@@ -81,8 +83,6 @@ runs:
         PROVIDER: ${{ inputs.provider }}
         PUBLIC_RPC: ${{ inputs.public-rpc }}
         RUST_LOG: ${{ inputs.rust-log }}
-        SAFENODE_VERSION: ${{ inputs.safenode-version }}
-        SAFENODE_MANAGER_VERSION: ${{ inputs.safenode-manager-version }}
       shell: bash
       run: |
         set -e
@@ -91,6 +91,9 @@ runs:
         command="testnet-deploy upscale \
           --name $NETWORK_NAME \
           --provider $PROVIDER "
+        [[ -n $ANT_VERSION ]] && command="$command --ant-version $ANT_VERSION "
+        [[ -n $ANTCTL_VERSION ]] && command="$command --antctl-version $ANTCTL_VERSION "
+        [[ -n $ANTNODE_VERSION ]] && command="$command --antnode-version $ANTNODE_VERSION "
         [[ -n $DESIRED_BOOTSTRAP_NODE_COUNT && $DESIRED_BOOTSTRAP_NODE_COUNT != "0" ]] && command="$command --desired-bootstrap-node-count $DESIRED_BOOTSTRAP_NODE_COUNT "
         [[ -n $DESIRED_BOOTSTRAP_NODE_VM_COUNT && $DESIRED_BOOTSTRAP_NODE_VM_COUNT != "0" ]] && command="$command --desired-bootstrap-node-vm-count $DESIRED_BOOTSTRAP_NODE_VM_COUNT "
         [[ -n $DESIRED_NODE_COUNT && $DESIRED_NODE_COUNT != "0" ]] && command="$command --desired-node-count $DESIRED_NODE_COUNT "
@@ -106,9 +109,6 @@ runs:
         [[ -n $MAX_LOG_FILES ]] && command="$command --max-log-files $MAX_LOG_FILES "
         [[ $PLAN == "true" ]] && command="$command --plan "
         [[ $PUBLIC_RPC == "true" ]] && command="$command --public-rpc "
-        [[ -n $AUTONOMI_VERSION ]] && command="$command --safe-version $AUTONOMI_VERSION "
-        [[ -n $SAFENODE_VERSION ]] && command="$command --safenode-version $SAFENODE_VERSION "
-        [[ -n $SAFENODE_MANAGER_VERSION ]] && command="$command --safenode-manager-version $SAFENODE_MANAGER_VERSION "
 
         echo "Will run testnet-deploy with: $command"
         eval $command


### PR DESCRIPTION
- b88c28f **chore: rename `launch-network` inputs for autonomi branding**

  We recently renamed our our binaries and crates and this has had other cascading effects on tools
  like `testnet-deploy`.

- 757a16d **chore: align inputs with new peer cache infra**

  Several changes here:
  * `bootstrap-`-related inputs have been changed to `peer-cache`.
  * Inputs for volume sizes have been added.
  * The key-based inputs have been removed, since these are no longer used any more.
  * A `network-id` input has been added.

- dcb3d75 **chore: rename `upscale` version inputs**

  This brings them in alignment with the rebranding.

- 3ca1dfc **chore: rename `upgrade-node-man` action to `upgrade-antctl`**


- 9b6272c **chore: provide `force` input for `upgrade-network`**


- ef838f3 **chore: rebrand the `bootstrap-network` action**

  The key-based arguments were also removed because these no longer apply.

  The wallet private key argument was removed. This only applies to uploaders and is not supported for
  the `bootstrap` command.