### PR TITLE
chore: print terraform version during setup

### DIFF
--- a/init-testnet-deploy/action.yml
+++ b/init-testnet-deploy/action.yml
@@ -63,6 +63,9 @@ runs:
       run: |
         set -e
 
+        # This is useful to obtain information on what providers are being used.
+        terraform version
+
         mkdir ~/.ssh
         echo "${{ inputs.ssh-secret-key }}" >> ~/.ssh/id_rsa
         chmod 0400 ~/.ssh/id_rsa


### PR DESCRIPTION
I need to obtain the version of the Digital Ocean provider that is being used with the runs on GHA.