### PR TITLE
feat: provide `telegraf-upgrade-geoip-config` action

### DIFF
--- a/telegraf-upgrade-client-config/action.yml
+++ b/telegraf-upgrade-client-config/action.yml
@@ -1,4 +1,4 @@
-name: Upgrade Node Telegraf Config
+name: Upgrade Client Telegraf Config
 description: Pull the latest Telegraf configuration from the network-dashboards repository
 inputs:
   ansible-forks:
@@ -22,7 +22,7 @@ runs:
         set -e
 
         cd sn-testnet-deploy
-        command="testnet-deploy upgrade-node-telegraf-config --name $NETWORK_NAME "
+        command="testnet-deploy telegraf upgrade-client-config --name $NETWORK_NAME "
         [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose "
         [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
 

--- a/telegraf-upgrade-geoip-config/action.yml
+++ b/telegraf-upgrade-geoip-config/action.yml
@@ -1,0 +1,30 @@
+name: Upgrade Node Telegraf Config
+description: Pull the latest Telegraf configuration from the network-dashboards repository
+inputs:
+  ansible-forks:
+    description: The number of forks to use with Ansible. Default is 50.
+  ansible-verbose:
+    description: Set to true to run Ansible with its most verbose output
+  network-name:
+    description: The name of the network to upgrade
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: upgrade telegraf
+      env:
+        ANSIBLE_FORKS: ${{ inputs.ansible-forks }}
+        ANSIBLE_VERBOSE: ${{ inputs.ansible-verbose }}
+        NETWORK_NAME: ${{ inputs.network-name }}
+      shell: bash
+      run: |
+        set -e
+
+        cd sn-testnet-deploy
+        command="testnet-deploy telegraf upgrade-geo-ip-config --name $NETWORK_NAME "
+        [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose "
+        [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
+
+        echo "Will run testnet-deploy with: $command"
+        eval $command

--- a/telegraf-upgrade-node-config/action.yml
+++ b/telegraf-upgrade-node-config/action.yml
@@ -1,4 +1,4 @@
-name: Upgrade Client Telegraf Config
+name: Upgrade Node Telegraf Config
 description: Pull the latest Telegraf configuration from the network-dashboards repository
 inputs:
   ansible-forks:
@@ -22,7 +22,7 @@ runs:
         set -e
 
         cd sn-testnet-deploy
-        command="testnet-deploy upgrade-client-telegraf-config --name $NETWORK_NAME "
+        command="testnet-deploy telegraf upgrade-node-config --name $NETWORK_NAME "
         [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose "
         [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
 


### PR DESCRIPTION
- 3e33948 **chore: use `telegraf` subcommand**

  The `testnet-deploy` binary was updated to group these commands under a `telegraf` subcommand, so
  these actions are subsequently updated.

  The roles are also renamed to align them closer to the name of the subcommand and also group them
  together.

- 1af59e6 **feat: provide `telegraf-upgrade-geoip-config` action**

  Provide action to run the new `telegraf upgrade-geoip-config` command in `testnet-deploy`.