### PR TITLE
feat: support new downloader inputs

### DIFF
--- a/launch-network/action.yml
+++ b/launch-network/action.yml
@@ -84,6 +84,8 @@ inputs:
     description: The size of the NAT gateway VM
   network-contacts-file-name:
     description: Provide a name for the network contacts file
+  network-dashboard-branch:
+    description: The branch of the network-dashboard repository to use
   network-id:
     description: The network ID (must be between 2 and 255)
     type: number
@@ -181,6 +183,7 @@ runs:
         MAX_LOG_FILES: ${{ inputs.max-log-files }}
         NAT_GATEWAY_VM_SIZE: ${{ inputs.nat-gateway-vm-size }}
         NETWORK_CONTACTS_FILE_NAME: ${{ inputs.network-contacts-file-name }}
+        NETWORK_DASHBOARD_BRANCH: ${{ inputs.network-dashboard-branch }}
         NETWORK_ID: ${{ inputs.network-id }}
         NETWORK_NAME: ${{ inputs.network-name }}
         NODE_COUNT: ${{ inputs.node-count }}
@@ -246,6 +249,7 @@ runs:
         [[ -n $MAX_LOG_FILES ]] && command="$command --max-log-files $MAX_LOG_FILES "
         [[ -n $NAT_GATEWAY_VM_SIZE ]] && command="$command --nat-gateway-vm-size $NAT_GATEWAY_VM_SIZE "
         [[ -n $NETWORK_CONTACTS_FILE_NAME ]] && command="$command --network-contacts-file-name $NETWORK_CONTACTS_FILE_NAME "
+        [[ -n $NETWORK_DASHBOARD_BRANCH ]] && command="$command --network-dashboard-branch $NETWORK_DASHBOARD_BRANCH "
         [[ -n $NETWORK_ID ]] && command="$command --network-id $NETWORK_ID "
         [[ -n $NODE_COUNT ]] && command="$command --node-count $NODE_COUNT "
         [[ -n $NODE_ENV ]] && command="$command --node-env $NODE_ENV "

--- a/launch-network/action.yml
+++ b/launch-network/action.yml
@@ -31,11 +31,18 @@ inputs:
     description: Number of client VMs to be deployed
   client-vm-size:
     description: The size of the Client VMs
+  disable-download-verifier:
+    description: Disable the download-verifier downloader on the VMs
+    default: false
+  disable-performance-verifier:
+    description: Disable the performance-verifier downloader on the VMs
+    default: false
+  disable-random-verifier:
+    description: Disable the random-verifier downloader on the VMs
+    default: false
   disable-telegraf:
     description: Disable Telegraf metrics collection if set to true
     default: false
-  enable-downloaders:
-    description: Enable all the various downloaders on the Client VMS if set to true.
   environment-type:
     description: >
       Possible values are 'development', 'staging' and 'production'. This value determines the sizes
@@ -152,8 +159,10 @@ runs:
         CLIENT_ENV: ${{ inputs.client-env }}
         CLIENT_VM_COUNT: ${{ inputs.client-vm-count }}
         CLIENT_VM_SIZE: ${{ inputs.client-vm-size }}
+        DISABLE_DOWNLOAD_VERIFIER: ${{ inputs.disable-download-verifier }}
+        DISABLE_PERFORMANCE_VERIFIER: ${{ inputs.disable-performance-verifier }}
+        DISABLE_RANDOM_VERIFIER: ${{ inputs.disable-random-verifier }}
         DISABLE_TELEGRAF: ${{ inputs.disable-telegraf }}
-        ENABLE_DOWNLOADERS: ${{ inputs.enable-downloaders }}
         ENVIRONMENT_TYPE: ${{ inputs.environment-type }}
         EVM_DATA_PAYMENTS_ADDRESS: ${{ inputs.evm-data-payments-address }}
         EVM_NETWORK_TYPE: ${{ inputs.evm-network-type }}
@@ -216,8 +225,10 @@ runs:
         [[ -n $CLIENT_ENV ]] && command="$command --client-env $CLIENT_ENV "
         [[ -n $CLIENT_VM_COUNT ]] && command="$command --client-vm-count $CLIENT_VM_COUNT "
         [[ -n $CLIENT_VM_SIZE ]] && command="$command --client-vm-size $CLIENT_VM_SIZE "
+        [[ $DISABLE_DOWNLOAD_VERIFIER == "true" ]] && command="$command --disable-download-verifier "
+        [[ $DISABLE_PERFORMANCE_VERIFIER == "true" ]] && command="$command --disable-performance-verifier "
+        [[ $DISABLE_RANDOM_VERIFIER == "true" ]] && command="$command --disable-random-verifier "
         [[ $DISABLE_TELEGRAF == "true" ]] && command="$command --disable-telegraf "
-        [[ $ENABLE_DOWNLOADERS == "true" ]] && command="$command --enable-downloaders "
         [[ -n $EVM_DATA_PAYMENTS_ADDRESS ]] && command="$command --evm-data-payments-address $EVM_DATA_PAYMENTS_ADDRESS "
         [[ -n $EVM_NETWORK_TYPE ]] && command="$command --evm-network-type $EVM_NETWORK_TYPE "
         [[ -n $EVM_NODE_VM_SIZE ]] && command="$command --evm-node-vm-size $EVM_NODE_VM_SIZE "

--- a/upscale-network/action.yml
+++ b/upscale-network/action.yml
@@ -53,6 +53,8 @@ inputs:
     description: Maximum number of archived log files to keep for each service
   max-log-files:
     description: Maximum number of log files to keep for each service
+  network-dashboard-branch:
+    description: The branch of the network-dashboard repository to use
   network-name:
     description: The name of the network
     required: true
@@ -98,6 +100,7 @@ runs:
         INTERVAL: ${{ inputs.interval }}
         MAX_ARCHIVED_LOG_FILES: ${{ inputs.max-archived-log-files }}
         MAX_LOG_FILES: ${{ inputs.max-log-files }}
+        NETWORK_DASHBOARD_BRANCH: ${{ inputs.network-dashboard-branch }}
         NETWORK_NAME: ${{ inputs.network-name }}
         NODE_ENV: ${{ inputs.node-env }}
         PLAN: ${{ inputs.plan }}
@@ -133,6 +136,7 @@ runs:
         [[ -n $INTERVAL ]] && command="$command --interval $INTERVAL "
         [[ -n $MAX_ARCHIVED_LOG_FILES ]] && command="$command --max-archived-log-files $MAX_ARCHIVED_LOG_FILES "
         [[ -n $MAX_LOG_FILES ]] && command="$command --max-log-files $MAX_LOG_FILES "
+        [[ -n $NETWORK_DASHBOARD_BRANCH ]] && command="$command --network-dashboard-branch $NETWORK_DASHBOARD_BRANCH "
         [[ -n $NODE_ENV ]] && command="$command --node-env $NODE_ENV "
         [[ $PLAN == "true" ]] && command="$command --plan "
         [[ $PUBLIC_RPC == "true" ]] && command="$command --public-rpc "


### PR DESCRIPTION
- 0f0434a **feat: support new downloader inputs**

  The `deploy` command now enables the downloaders by default and instead provides flags for disabling
  the services if need be.

- 3da544e **feat: provide `network-dashboard-branch` inputs**

  Both the `deploy` and `upscale` commands are going to support an argument for varying the branch
  used for the `network-dashboard` repository.