### PR TITLE
chore: debugging output to print version

### DIFF
--- a/init-testnet-deploy/action.yml
+++ b/init-testnet-deploy/action.yml
@@ -113,6 +113,7 @@ runs:
           version=$(curl --silent https://crates.io/api/v1/crates/sn-testnet-deploy | \
             jq -r .crate.newest_version)
         fi
+        echo "Using version $version of testnet-deploy"
 
         # We still need the source because that's where the Terraform and Ansible files are. Longer
         # term we could copy these to a system-wide location and extend the testnet tool to look


### PR DESCRIPTION
For some reason there is now a failure when trying to check out a particular version of testnet-deploy.

Adding some debugging text just to confirm if we are getting rate-limited or something when we try to get the latest version from `crates.io`.