### PR TITLE
chore: check the version returned by crates.io

### DIFF
--- a/init-testnet-deploy/action.yml
+++ b/init-testnet-deploy/action.yml
@@ -121,7 +121,11 @@ runs:
         git clone https://github.com/maidsafe/sn-testnet-deploy
         (
           cd sn-testnet-deploy
-          git checkout v${version}
+          # In this case, it seems that crates.io is not returning the version for
+          # the crate. So we can just go with the latest code.
+          if [[ "$version" != "null" ]]; then
+            git checkout v${version}
+          fi
         )
 
         curl -L -O $BASE_URL/testnet-deploy-${version}-x86_64-unknown-linux-musl.zip


### PR DESCRIPTION
It seems the case that the request to retrieve the latest version from crates.io possibly gets rate limited when the request is made from Github. If I run the same request from my dev machine, it is fine, but when run from Github it is returning the string "null".

If the version hasn't been retrieved correctly, we can just use the latest code rather than check out a specific version.