### PR TITLE
chore: rename full cone vm size inputs/args

### DIFF
--- a/init-testnet-deploy/action.yml
+++ b/init-testnet-deploy/action.yml
@@ -46,10 +46,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update -y
-        # There is some issue with the latest version of Ansible not correctly
-        # reading the Digital Ocean token from environment variables, so just
-        # pin to this version for now.
-        pip install --user ansible==8.2.0
+        pip install --user ansible
         pip install --user boto3
         sudo apt-get install jq -y
     - name: configure testnet-deploy

--- a/launch-network/action.yml
+++ b/launch-network/action.yml
@@ -60,7 +60,7 @@ inputs:
     description: The address of the EVM payment token contract
   evm-rpc-url:
     description: The RPC URL for the EVM network when using a custom network type
-  full-cone-private-nat-gateway-vm-size:
+  full-cone-vm-size:
     description: The size of the NAT gateway VM for full cone private nodes
   full-cone-private-node-count:
     description: Number of node services to run on each full cone private node VM
@@ -173,7 +173,7 @@ runs:
         EVM_NODE_VM_SIZE: ${{ inputs.evm-node-vm-size }}
         EVM_PAYMENT_TOKEN_ADDRESS: ${{ inputs.evm-payment-token-address }}
         EVM_RPC_URL: ${{ inputs.evm-rpc-url }}
-        FULL_CONE_PRIVATE_NAT_GATEWAY_VM_SIZE: ${{ inputs.full-cone-private-nat-gateway-vm-size }}
+        FULL_CONE_VM_SIZE: ${{ inputs.full-cone-vm-size }}
         FULL_CONE_PRIVATE_NODE_COUNT: ${{ inputs.full-cone-private-node-count }}
         FULL_CONE_PRIVATE_NODE_VM_COUNT: ${{ inputs.full-cone-private-node-vm-count }}
         FULL_CONE_PRIVATE_NODE_VOLUME_SIZE: ${{ inputs.full-cone-private-node-volume-size }}
@@ -240,7 +240,7 @@ runs:
         [[ -n $EVM_NODE_VM_SIZE ]] && command="$command --evm-node-vm-size $EVM_NODE_VM_SIZE "
         [[ -n $EVM_PAYMENT_TOKEN_ADDRESS ]] && command="$command --evm-payment-token-address $EVM_PAYMENT_TOKEN_ADDRESS "
         [[ -n $EVM_RPC_URL ]] && command="$command --evm-rpc-url \"$EVM_RPC_URL\" "
-        [[ -n $FULL_CONE_PRIVATE_NAT_GATEWAY_VM_SIZE ]] && command="$command --full-cone-private-nat-gateway-vm-size $FULL_CONE_PRIVATE_NAT_GATEWAY_VM_SIZE "
+        [[ -n $FULL_CONE_VM_SIZE ]] && command="$command --full-cone-vm-size $FULL_CONE_VM_SIZE "
         [[ -n $FULL_CONE_PRIVATE_NODE_COUNT ]] && command="$command --full-cone-private-node-count $FULL_CONE_PRIVATE_NODE_COUNT "
         [[ -n $FULL_CONE_PRIVATE_NODE_VM_COUNT ]] && command="$command --full-cone-private-node-vm-count $FULL_CONE_PRIVATE_NODE_VM_COUNT "
         [[ -n $FULL_CONE_PRIVATE_NODE_VOLUME_SIZE ]] && command="$command --full-cone-private-node-volume-size $FULL_CONE_PRIVATE_NODE_VOLUME_SIZE "


### PR DESCRIPTION
- d9d60d4 **chore: remove ansible version constraint**

  We can now run on the latest version of Ansible.

- 9f9b993 **chore: rename full cone vm size inputs/args**

  This argument was recently renamed with a rework of the full cone private node setup.